### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var requests = {};
 var TIMEOUT = 60000;
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       "name": "Alexandre Tiertant",
       "github": "https://github.com/atiertant"
     }
-  ],  
+  ],
   "description": "small framework",
   "main": "lib/platform.js",
   "scripts": {
@@ -23,15 +23,15 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "lodash": "~2.4.1",
     "asynk": "~0.0.9",
-    "node-uuid": "~1.4.7",
+    "lodash": "~2.4.1",
     "mime": "~1.3.4",
-    "socket.io": "~1.4.4",
     "offshore-validator": "~0.0.1",
-    "serve-static": "~1.10.0"
+    "serve-static": "~1.10.0",
+    "socket.io": "~1.4.4",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "~2.3.4"
-  } 
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.